### PR TITLE
Manage nginx/supervisor configs through versioned releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,12 @@ jobs:
         env:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          rm -rf pkg && mkdir -p pkg/static pkg/server
+          rm -rf pkg && mkdir -p pkg/static pkg/server pkg/deploy
           cp -R client/dist/. pkg/static/
           # backend source needed to `pip install` on the host (no build there)
           cp -R server/setup.py server/MANIFEST.in server/snapfile pkg/server/
+          # nginx/supervisor configs, so the installer manages them per-release
+          cp deploy/snapfile.conf deploy/supervisord.ini pkg/deploy/
           tar -czf "snapfile-${VERSION}.tar.gz" -C pkg .
           echo "Artifact contents:" && tar -tzf "snapfile-${VERSION}.tar.gz" | head -20
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,12 @@ atomic symlink flip:
     |-- releases
     |   |-- v1.0.0
     |   |   |-- static   (prebuilt Vue client, served by NGINX)
-    |   |   `-- server   (backend source, pip-installed)
+    |   |   |-- server   (backend source, pip-installed)
+    |   |   `-- deploy   (nginx/supervisor configs for this version)
     |   `-- v1.1.0
     |       |-- static
-    |       `-- server
+    |       |-- server
+    |       `-- deploy
     |-- current -> releases/v1.1.0
     |-- static  -> current/static    (NGINX root)
     |-- files   (uploads — shared across versions)
@@ -94,11 +96,16 @@ atomic symlink flip:
     `-- logs
 ```
 
-> The first run also installs prerequisites (nginx/redis/supervisor), creates the
-> directories, and sets up the redis/nginx/supervisor config (it won't clobber an
-> existing nginx config, so local customizations are preserved). In production
-> (`ENV=PROD`) NGINX serves the static files; the Python backend only serves the
-> APIs and websocket.
+> The nginx/supervisor configs are **versioned with each release** (`deploy/` in
+> the artifact). On every deploy/rollback the installer repoints
+> `/etc/nginx/conf.d/snapfile.conf` and `/etc/supervisord.d/snapfile.ini` at the
+> active release's configs, runs `nginx -t` and reloads (restoring the previous
+> config if the test fails), and `supervisorctl reread && update`. So config
+> changes ship through the repo like everything else. Host-specific tweaks (e.g.
+> the shared `$connection_upgrade` map) live in `deploy/snapfile.conf`. The first
+> run also installs prerequisites and creates the directories. In production
+> (`ENV=PROD`) NGINX serves the static files; the backend only serves the APIs
+> and websocket.
 
 
 ## Development

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -34,7 +34,6 @@ KEEP_RELEASES=5
 HEALTHCHECK_URL="${HEALTHCHECK_URL:-https://snapfile.yanxurui.cc/login.html}"
 
 PIP="/home/$user/.pyenv/versions/$pyversion/bin/pip"
-DEPLOY_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 log()  { echo -e "\033[1;32m[deploy]\033[0m $*"; }
 warn() { echo -e "\033[1;33m[deploy]\033[0m $*" >&2; }
@@ -62,15 +61,10 @@ ensure_host() {
         grep -q "^dir ${prefix}/db" /etc/redis.conf || sed -i "s|^dir .*|dir ${prefix}/db|" /etc/redis.conf
     fi
 
-    # nginx/supervisor configs: only create if absent, so local customizations
-    # (e.g. a shared map in conf.d/common.conf, IPv6 listen) are preserved.
-    if [ ! -e /etc/nginx/conf.d/snapfile.conf ]; then
-        ln -s "$DEPLOY_DIR/snapfile.conf" /etc/nginx/conf.d/snapfile.conf
-    fi
-    if [ ! -e /etc/supervisord.d/snapfile.ini ]; then
-        ln -s "$DEPLOY_DIR/supervisord.ini" /etc/supervisord.d/snapfile.ini
-        systemctl restart supervisord || true
-    fi
+    # make sure the services are running (no-op if already up)
+    systemctl enable --now nginx redis supervisord >/dev/null 2>&1 || true
+    # The nginx/supervisor configs are shipped in each release and pointed at
+    # per-release by link_configs() — not symlinked from the repo here.
 }
 
 # ---- fetch a release into releases/<version> -------------------------------
@@ -95,8 +89,8 @@ fetch_release() {
     mkdir -p "$dir"
     tar -xzf "$tarball" -C "$dir"
     rm -f "$tarball"
-    [ -f "$dir/static/index.html" ] && [ -f "$dir/server/setup.py" ] \
-        || die "artifact for $version is missing static/ or server/"
+    [ -f "$dir/static/index.html" ] && [ -f "$dir/server/setup.py" ] && [ -f "$dir/deploy/snapfile.conf" ] \
+        || die "artifact for $version is missing static/, server/ or deploy/"
     chown -R "$user" "$dir"
     log "unpacked release $version"
 }
@@ -133,6 +127,32 @@ activate() {
     mv -Tf "$prefix/static.tmp" "$prefix/static"
     chown -h "$user" "$prefix/current" "$prefix/static" 2>/dev/null || true
     log "active release is now $version"
+}
+
+# ---- point nginx/supervisor at the active release's configs ----------------
+link_configs() {
+    local active conf
+    active="$(readlink "$prefix/current")"   # absolute releases/<version>
+    conf="$active/deploy"
+    log "linking nginx/supervisor configs to $(basename "$active")..."
+
+    # nginx: stage the new (version-pinned) symlink, validate, then reload.
+    # On failure, restore the previous config so a bad release can never take
+    # the site down or block a future nginx restart.
+    cp -aP /etc/nginx/conf.d/snapfile.conf /etc/nginx/conf.d/snapfile.conf.prev 2>/dev/null || true
+    ln -sfn "$conf/snapfile.conf" /etc/nginx/conf.d/snapfile.conf
+    if nginx -t; then
+        systemctl reload nginx
+        rm -f /etc/nginx/conf.d/snapfile.conf.prev
+    else
+        [ -e /etc/nginx/conf.d/snapfile.conf.prev ] \
+            && mv -f /etc/nginx/conf.d/snapfile.conf.prev /etc/nginx/conf.d/snapfile.conf
+        die "nginx config test failed for this release; restored the previous config and aborted"
+    fi
+
+    # supervisor: update the program config; `update` restarts only if it changed
+    ln -sfn "$conf/supervisord.ini" /etc/supervisord.d/snapfile.ini
+    supervisorctl reread >/dev/null 2>&1 && supervisorctl update >/dev/null 2>&1 || true
 }
 
 restart_app() {
@@ -179,6 +199,7 @@ deploy() {
     fetch_release "$version"
     install_backend "$version"
     activate "$version"
+    link_configs
     restart_app
     health_check
     prune_releases
@@ -192,6 +213,7 @@ rollback() {
     log "rolling back to $version ..."
     install_backend "$version"
     activate "$version"
+    link_configs
     restart_app
     health_check
     log "rolled back to $version"

--- a/deploy/snapfile.conf
+++ b/deploy/snapfile.conf
@@ -1,9 +1,13 @@
 limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
 
-map $http_upgrade $connection_upgrade {
-    default upgrade;
-    '' close;
-}
+# $connection_upgrade is defined once in a shared include (conf.d/common.conf)
+# on the deploy host, so the map is commented out here to avoid a duplicate
+# "map" directive. If you deploy to a host WITHOUT that shared map, uncomment
+# this block — nginx needs $connection_upgrade defined for the /ws location.
+# map $http_upgrade $connection_upgrade {
+#     default upgrade;
+#     '' close;
+# }
 
 upstream backend {
     server localhost:8080;


### PR DESCRIPTION
Makes the installer own the nginx/supervisor configs instead of skipping them.

- Release artifact now includes `deploy/snapfile.conf` + `supervisord.ini` (unpacks to `releases/<version>/deploy/`).
- `install.sh` repoints `/etc` at the active release's configs on every deploy/rollback, `nginx -t` + reload (restoring the previous config on failure), `supervisorctl reread && update`.
- `deploy/snapfile.conf` reconciled to the live host config (the `$http_upgrade` map is commented — it's in the host's shared `conf.d/common.conf`).

After merge I'll cut a new release and deploy it to verify config management end-to-end.